### PR TITLE
feat(build): add gitlab-ci job for building of the oci image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+build:
+  image:
+    name: "nixpkgs/nix-flakes:nixos-23.05"
+  script:
+    - nix build .\#docker --out-link result-link
+    - cp -f $(readlink result-link) python-kidra_oci-image.tar.gz
+  artifacts:
+    paths:
+      - python-kidra_oci-image.tar.gz


### PR DESCRIPTION
Notes: The current implementation of this build job is very simple. It simply starts a new build process from scratch, possibly utilizing the pre-built artifacts from cache.nixos.org, and exports the resulting OCI image as an artifact.

This can be improved in multiple ways, e.g. by utilizing the persistent caching mechanism of Nix through a persistent building container (see build.sh for a local implementation of this).